### PR TITLE
Add optional key_id on auditor response

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -159,7 +159,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -223,7 +223,7 @@ checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -389,6 +389,7 @@ checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown",
+ "serde",
 ]
 
 [[package]]
@@ -470,7 +471,7 @@ dependencies = [
 
 [[package]]
 name = "plexi_cli"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap",
@@ -484,7 +485,7 @@ dependencies = [
 
 [[package]]
 name = "plexi_core"
-version = "0.0.1"
+version = "0.1.0"
 dependencies = [
  "bincode",
  "ed25519-dalek",
@@ -492,7 +493,9 @@ dependencies = [
  "prost",
  "prost-build",
  "serde",
+ "serde_json",
  "thiserror",
+ "utoipa",
  "uuid",
 ]
 
@@ -503,7 +506,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.71",
+]
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
 ]
 
 [[package]]
@@ -542,7 +569,7 @@ dependencies = [
  "prost",
  "prost-types",
  "regex",
- "syn",
+ "syn 2.0.71",
  "tempfile",
 ]
 
@@ -556,7 +583,7 @@ dependencies = [
  "itertools",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -666,7 +693,7 @@ checksum = "e0cd7e117be63d3c3678776753929474f3b04a43a080c744d6b0ae2a8c28e222"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -724,6 +751,16 @@ checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
 version = "2.0.71"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b146dcf730474b4bcd16c311627b31ede9ab149045db4d6088b3becaea046462"
@@ -762,7 +799,7 @@ checksum = "a4558b58466b9ad7ca0f102865eccc95938dca1a74a856f2b57b6629050da261"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.71",
 ]
 
 [[package]]
@@ -782,6 +819,30 @@ name = "utf8parse"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
+name = "utoipa"
+version = "4.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5afb1a60e207dca502682537fefcfd9921e71d0b83e9576060f09abc6efab23"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_json",
+ "utoipa-gen",
+]
+
+[[package]]
+name = "utoipa-gen"
+version = "4.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bf0e16c02bc4bf5322ab65f10ab1149bdbcaa782cba66dc7057370a3f8190be"
+dependencies = [
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.71",
+]
 
 [[package]]
 name = "uuid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,11 +5,25 @@ members = [
 ]
 resolver = "2"
 
+[workspace.package]
+version = "0.1.0"
+authors = [
+    "Thibault Meunier <thibault@cloudflare.com>", # utoipa only supports the first author as contact
+    "Fisher Darling <fisher@cloudflare.com>",
+    "JP Borges <jborges@cloudflare.com>"
+]
+edition = "2021"
+readme = "README.md"
+homepage = "https://github.com/cloudflare/plexi"
+repository = "https://github.com/thibmeu/plexi"
+keywords = ["transparency", "e2ee", "auditor", "cryptography"]
+categories = ["cryptography"]
+license = "Apache-2.0"
+
 [workspace.dependencies]
 anyhow = "1.0"
 bincode = "2.0.0-rc.3"
 bytes = "1.6"
-cfg-if = "1.0"
 console_error_panic_hook = { version = "0.1" }
 clap = { version = "4.5", features = ["derive"] }
 clap-verbosity-flag = "2.2.0"
@@ -25,8 +39,10 @@ rand = { version = "0.8", default-features = false, features = ["getrandom"] }
 serde = "1.0"
 serde_json = "1.0"
 thiserror = { version = "1.0" }
+utoipa = "4"
+utoipa-redoc = "4"
 uuid = { version = "1.9", features = ["v4", "serde"] }
-worker = { version = "0.3.0", features = ["d1"] }
+worker = "0.3.1"
 
 # workspace dependencies
 plexi_core = { path = "./plexi_core" }

--- a/plexi_cli/Cargo.toml
+++ b/plexi_cli/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "plexi_cli"
 description = "A flexible auditor companion client"
-version = "0.0.1"
-authors = ["Thibault Meunier <thibault@cloudflare.com>"]
-edition = "2021"
-readme = "README.md"
-homepage = "https://github.com/cloudflare/plexi"
-repository = "https://github.com/thibmeu/plexi"
-keywords = ["transparency", "e2ee", "auditor", "cryptography", "cli"]
-categories = ["cryptography"]
-license = "Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 
 [[bin]]
 name = "plexi"

--- a/plexi_core/Cargo.toml
+++ b/plexi_core/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
 name = "plexi_core"
 description = "A flexible auditor companion client"
-version = "0.0.1"
-authors = ["Thibault Meunier <thibault@cloudflare.com>"]
-edition = "2021"
-readme = "../README.md"
-homepage = "https://github.com/cloudflare/plexi"
-repository = "https://github.com/thibmeu/plexi"
-keywords = ["transparency", "e2ee", "auditor", "cryptography"]
-categories = ["cryptography"]
-license = "Apache-2.0"
+version.workspace = true
+authors.workspace = true
+edition.workspace = true
+license.workspace = true
+readme.workspace = true
+homepage.workspace = true
+repository.workspace = true
+keywords.workspace = true
+categories.workspace = true
 build = "src/build.rs"
+
+[features]
+default = ["openapi"]
+openapi = ["utoipa"]
 
 [dependencies]
 bincode = { workspace = true }
@@ -19,7 +23,11 @@ hex = { workspace = true, features = ["serde"] }
 prost = { workspace = true }
 serde = { workspace = true, features = ["derive"] }
 thiserror = { workspace = true }
+utoipa = { workspace = true, optional = true }
 uuid = { workspace = true, features = ["v4", "serde"] }
+
+[dev-dependencies]
+serde_json = { workspace = true }
 
 [build-dependencies]
 prost-build = { version = "0.13" }

--- a/plexi_core/src/crypto.rs
+++ b/plexi_core/src/crypto.rs
@@ -1,0 +1,7 @@
+use ed25519_dalek::PUBLIC_KEY_LENGTH;
+
+pub fn ed25519_public_key_to_key_id(public_key: &[u8; PUBLIC_KEY_LENGTH]) -> u8 {
+    *public_key
+        .last()
+        .expect("fixed size array has a last element")
+}

--- a/plexi_core/src/proto/specs/types.proto
+++ b/plexi_core/src/proto/specs/types.proto
@@ -16,4 +16,5 @@ message SignatureMessage {
 message SignatureResponse {
     required SignatureMessage message = 1;
     required bytes signature = 2;
+    optional uint32 key_id = 3;
 }

--- a/plexi_core/tests/test-vectors.json
+++ b/plexi_core/tests/test-vectors.json
@@ -1,0 +1,24 @@
+[
+    {
+        "signing_key": "d6af1bca3db4fc2766b0c483706c20bf4837a46d54c1d39c2a34a9088572d712",
+        "verifying_key": "606a878700158d92b3a14a0fd37ec82e0f05f92fcf23146abfda2e3a2f10a9bc",
+        "key_id": 188,
+        "namespace": "log1.example.test",
+        "timestamp": 1717084639921,
+        "epoch": 1,
+        "digest": "1111111111111111111111111111111111111111111111111111111111111111",
+        "signature": "31fbef3ed02ea0c8570e3740857d343857118102698a0822ee070a03d7a20637d6507fc855669ac30b959d6a0d35cba455a39e287ce2a101dbc16236027a400c",
+        "signature_version": 1
+    },
+    {
+        "signing_key": "d6af1bca3db4fc2766b0c483706c20bf4837a46d54c1d39c2a34a9088572d712",
+        "verifying_key": "606a878700158d92b3a14a0fd37ec82e0f05f92fcf23146abfda2e3a2f10a9bc",
+        "key_id": 188,
+        "namespace": "log2.example.test",
+        "timestamp": 1717084639921,
+        "epoch": 1,
+        "digest": "1111111111111111111111111111111111111111111111111111111111111111",
+        "signature": "9e666ec61efb48e7d0a4c63f9eb50ab3d1674ac7841d97e1a2d85946a7da00bde6ce2dff0d56bcf40d61f4cfcac290001cf20b662c5e223f5e8ce192bb0f7101",
+        "signature_version": 2
+    }
+]


### PR DESCRIPTION
The auditor MAY return `key_id`, representing the last byte of the public key used for signing.
plexi_cli validates it.

In addition, we provide two test vectors, for signature 0x0001 and 0x0002.