### PR TITLE
Update proto to required

### DIFF
--- a/plexi_core/src/proto/specs/types.proto
+++ b/plexi_core/src/proto/specs/types.proto
@@ -2,7 +2,7 @@ syntax = "proto2";
 package plexi_core.types;
 
 message Epoch {
-    optional uint64 inner = 1;
+    required uint64 inner = 1;
 }
 
 message SignatureMessage {


### PR DESCRIPTION
move the inner value to required for epoch, as there is no real need for optional in this type alias