### PR TITLE
Add user agent while fetching

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -72,7 +72,7 @@ jobs:
           command: fetch
       - name: Build for target
         working-directory: ./plexi_core
-        run: cargo build --verbose --no-default-features --target ${{ matrix.target }}
+        run: cargo build --verbose --no-default-features --features bincode --target ${{ matrix.target }}
 
   bitrot:
     name: Bitrot

--- a/plexi_core/Cargo.toml
+++ b/plexi_core/Cargo.toml
@@ -15,9 +15,9 @@ build = "src/build.rs"
 [features]
 default = ["openapi", "bincode"]
 auditor = ["akd", "akd/parallel_vrf", "akd/parallel_insert", "akd/experimental"]
-client = ["auditor", "reqwest", "bincode"]
-openapi = ["utoipa"]
 bincode = ["dep:bincode"]
+client = ["auditor", "bincode", "reqwest"]
+openapi = ["utoipa"]
 
 [dependencies]
 akd = { workspace = true, features = ["whatsapp_v1", "public_auditing"], optional = true }

--- a/plexi_core/src/client/mod.rs
+++ b/plexi_core/src/client/mod.rs
@@ -22,7 +22,11 @@ impl fmt::Debug for PlexiClient {
 }
 
 impl PlexiClient {
-    pub fn new(base_url: Url, mtls: Option<ClientMtls>) -> anyhow::Result<Self> {
+    pub fn new(
+        base_url: Url,
+        mtls: Option<ClientMtls>,
+        user_agent: Option<&str>,
+    ) -> anyhow::Result<Self> {
         let mut client_builder = Client::builder();
 
         if let Ok(bundle) = std::env::var("SSL_CERT_FILE") {
@@ -44,6 +48,10 @@ impl PlexiClient {
 
         if let Some(mtls) = mtls {
             client_builder = client_builder.identity(mtls.identity);
+        }
+
+        if let Some(user_agent) = user_agent {
+            client_builder = client_builder.user_agent(user_agent);
         }
 
         Ok(Self {

--- a/plexi_core/src/proto/specs/types.proto
+++ b/plexi_core/src/proto/specs/types.proto
@@ -6,7 +6,7 @@ message Epoch {
 }
 
 message SignatureMessage {
-    required uint32 version = 1;
+    required uint32 ciphersuite = 1;
     required string namespace = 2;
     required uint64 timestamp = 3;
     required Epoch epoch = 4;

--- a/plexi_core/tests/test-vectors.json
+++ b/plexi_core/tests/test-vectors.json
@@ -8,7 +8,7 @@
         "epoch": 1,
         "digest": "1111111111111111111111111111111111111111111111111111111111111111",
         "signature": "769d1ae73792dd8da1515793ba29f2f33f2fca84ba7386f9a01d8272e67c4379bdcfd91ea4fa49eafd8f243ac36fe3a7aae90ae92f1729c3c468ddf4e6d2a309",
-        "signature_version": 1
+        "ciphersuite": 1
     },
     {
         "signing_key": "d6af1bca3db4fc2766b0c483706c20bf4837a46d54c1d39c2a34a9088572d712",
@@ -19,6 +19,6 @@
         "epoch": 1,
         "digest": "1111111111111111111111111111111111111111111111111111111111111111",
         "signature": "a73807da5d7e12f7ed6328c918e2071173793fea3af96d98f0a649a5f498b5bfebbe96ce7b21b027ccc04e69ac8cf40c2ed2d45ee23b0c30c00abca9753f7909",
-        "signature_version": 2
+        "ciphersuite": 2
     }
 ]


### PR DESCRIPTION
Add signature_version -> ciphersuite
Ensure Ciphersuite array is static, while bincode serialisation is only supported when bincode option is enabled.
