### PR TITLE
Add local verification on plexi cli

### DIFF
--- a/plexi_cli/src/cli.rs
+++ b/plexi_cli/src/cli.rs
@@ -1,3 +1,5 @@
+use std::path::PathBuf;
+
 use clap::{Parser, Subcommand};
 use plexi_core::Epoch;
 
@@ -47,6 +49,25 @@ pub enum Commands {
         /// Enable detailed output
         #[arg(short, long, default_value_t = false, group = "format")]
         long: bool,
+    },
+    #[command(verbatim_doc_comment)]
+    LocalAudit {
+        /// Ed25519 public key in hex format.
+        #[arg(long, env = "PLEXI_VERIFYING_KEY")]
+        verifying_key: Option<String>,
+        /// Enable detailed output
+        #[arg(short, long, default_value_t = false, group = "format")]
+        long: bool,
+        /// Disable signature and proof validation
+        #[arg(long, default_value_t = false, env = "PLEXI_VERIFICATION_DISABLED")]
+        no_verify: bool,
+        /// Path to a file containing an epoch consistency proof
+        /// Format is still ad-hoc, based on AKD
+        #[arg(long, env = "PLEXI_PROOF_PATH")]
+        proof_path: Option<PathBuf>,
+        /// Path to a file containing an epoch to verify
+        /// Format is { ciphersuite, namespace, timestamp, epoch, digest, signature }
+        signature_path_or_stdin: Option<PathBuf>,
     },
 }
 

--- a/plexi_cli/src/main.rs
+++ b/plexi_cli/src/main.rs
@@ -2,6 +2,7 @@ use std::process;
 
 mod cli;
 mod cmd;
+mod print;
 
 #[tokio::main]
 pub async fn main() -> anyhow::Result<()> {
@@ -32,6 +33,22 @@ pub async fn main() -> anyhow::Result<()> {
                 !no_verify,
                 verifying_key.as_deref(),
                 epoch.as_ref(),
+            )
+            .await
+        }
+        cli::Commands::LocalAudit {
+            verifying_key,
+            long,
+            no_verify,
+            proof_path,
+            signature_path_or_stdin,
+        } => {
+            cmd::audit_local(
+                verifying_key.as_deref(),
+                long,
+                !no_verify,
+                proof_path,
+                signature_path_or_stdin,
             )
             .await
         }

--- a/plexi_cli/src/print.rs
+++ b/plexi_cli/src/print.rs
@@ -1,0 +1,22 @@
+use std::io::Write as _;
+
+use log::log_enabled;
+use tokio::{
+    task::JoinHandle,
+    time::{interval, Duration},
+};
+
+pub fn print_dots() -> JoinHandle<()> {
+    async fn print_dots_routine() {
+        let mut interval = interval(Duration::from_secs(1));
+        loop {
+            interval.tick().await;
+            if log_enabled!(log::Level::Error) {
+                eprint!(".");
+            }
+            std::io::stderr().flush().unwrap();
+        }
+    }
+
+    tokio::spawn(print_dots_routine())
+}


### PR DESCRIPTION
This commit adds the ability to perform local validation of proof and signature with plexi.

You can run the following example
```
\# Set auditor validation key
PLEXI_VERIFYING_KEY="$(curl -sS https://plexi.key-transparency.cloudflare.com/info | jq -r '.keys[0].public_key')"

\# Download an akd proof
curl -sS https://d1tfr3x7n136ak.cloudfront.net/458298/5f02bf9c5526151669914c4b80a300870e583b6b32e2c537ee4fa4f589fe889d/3ae9497069cc722dc9e00f8251da87071646a57dae2fc7882f1d8214961d80bd > /tmp/proof

\# Retrieve epoch, and pass it to the local audit alongside the proof
curl -sS https://plexi.key-transparency.cloudflare.com/namespaces/whatsapp.key-transparency.v1/audits/458298 | cargo run -- local-audit --proof-path /tmp/proof --long
```

To do before merge
* Add test with real data, possibly the above example. I need to find the right too in Rust to do this
* Consider overloading `plexi audit` instead. If an input is present on stdin, or an input path is provided, it's local validation. This might be too complex
* Consider printing the previous epoch infered from the provided consistency proof

Closes #12

cc @henrywang8atfbdotcom